### PR TITLE
docs: Fix link to architecture diagram

### DIFF
--- a/docs/contributor/README.md
+++ b/docs/contributor/README.md
@@ -8,7 +8,7 @@ To bill hyperscaler resources used by SKR clusters, the Kyma Control Plane (KCP)
 
 Every SKR cluster runs in a hyperscaler account dedicated to the related global account, so it is shared between many clusters of the same customer. The hyperscaler account is paid by Kyma, and individual resource usage is charged to the customer. The bill to the end user contains one entry, listing the consumed capacity units (CU) without any further breakdown. The bill is created by the Unified Metering service.
 
-[!arch](./assets/arch.drawio.svg)
+![arch](./assets/arch.drawio.svg)
 
 The following step happens once for every SKR registration and deregistration:
 


### PR DESCRIPTION
## Description

Changes proposed in this pull request (what was done and why):

- Fix the link to the architecture diagram in contributor documentation

Changes refer to particular issues, PRs or documents:

- 

## Traceability
- [ ] The PR is linked to a GitHub issue.
- [ ] The follow-up issues (if any) are linked in the `Related Issues` section.
- [ ] If the change is user-facing, the documentation has been adjusted.
- [ ] If a CRD is changed, the corresponding Busola ConfigMap has been adjusted.
- [ ] The feature is unit-tested.
- [ ] The feature is e2e-tested.

<!--  
Thank you for your contribution!

Before submitting your pull request, adhere to contributing guidelines, templates, the recommended Git workflow, and related documentation, see also https://github.com/kyma-project/community/blob/main/docs/contributing/02-contributing.md
 -->
