### PR TITLE
fix: Check if status is set in vsc handling

### DIFF
--- a/pkg/collector/edp/collector.go
+++ b/pkg/collector/edp/collector.go
@@ -57,6 +57,7 @@ func (c *Collector) CollectAndSend(ctx context.Context, runtime *runtime.Info, p
 
 	if len(EDPMeasurements) == 0 {
 		errs = append(errs, errNoMeasurementsSent)
+
 		span.RecordError(err)
 		span.SetStatus(codes.Error, errNoMeasurementsSent.Error())
 
@@ -90,6 +91,7 @@ func (c *Collector) executeScans(ctx context.Context, previousScans collector.Sc
 		scan, err := s.Scan(ctx, runtime)
 		success := err == nil
 		collector.RecordScan(success, string(s.ID()), *runtime)
+
 		if success {
 			currentScans[s.ID()] = scan
 			continue
@@ -126,7 +128,9 @@ func (c *Collector) convertScansToEDPMeasurements(currentScans collector.ScanMap
 		// if the scan can be converted to an EDP measurement, we add it to the convertableScans and EDPMeasurements
 		if success {
 			convertableScans[id] = scan
+
 			EDPMeasurements = append(EDPMeasurements, EDPMeasurement)
+
 			continue
 		}
 
@@ -148,6 +152,7 @@ func (c *Collector) convertScansToEDPMeasurements(currentScans collector.ScanMap
 
 		// if the previous scan can be converted to an EDP measurement, we add it to convertableScans and its measurement is added to EDPMeasurements
 		convertableScans[id] = previousScan
+
 		EDPMeasurements = append(EDPMeasurements, EDPMeasurement)
 	}
 

--- a/pkg/resource/vsc/scan.go
+++ b/pkg/resource/vsc/scan.go
@@ -37,10 +37,10 @@ func (s *Scan) EDP() (resource.EDPMeasurement, error) {
 
 	for _, vsc := range s.vscs.Items {
 		if vsc.Status == nil {
-
 			errs = append(errs, fmt.Errorf("%w: %s", ErrStatusNotSet, vsc.Name))
 			continue
 		}
+
 		if vsc.Status.ReadyToUse != nil && *vsc.Status.ReadyToUse {
 			currVSC := getSizeInGB(*vsc.Status.RestoreSize)
 			edp.ProvisionedVolumes.SizeGbTotal += currVSC

--- a/pkg/resource/vsc/scan.go
+++ b/pkg/resource/vsc/scan.go
@@ -47,6 +47,7 @@ func (s *Scan) EDP() (resource.EDPMeasurement, error) {
 				errs = append(errs, fmt.Errorf("%w: %s", ErrRestoreSizeNotSet, vsc.Name))
 				continue
 			}
+
 			currVSC := getSizeInGB(*vsc.Status.RestoreSize)
 			edp.ProvisionedVolumes.SizeGbTotal += currVSC
 			edp.ProvisionedVolumes.SizeGbRounded += getVolumeRoundedToFactor(currVSC)

--- a/pkg/resource/vsc/scan.go
+++ b/pkg/resource/vsc/scan.go
@@ -1,6 +1,8 @@
 package vsc
 
 import (
+	"errors"
+	"fmt"
 	"math"
 	"time"
 
@@ -16,7 +18,10 @@ const (
 	GiB = 1 << (10 * 3) //nolint:mnd // 1 GiB = 1024^3 bytes
 )
 
-var _ resource.ScanConverter = &Scan{}
+var (
+	_               resource.ScanConverter = &Scan{}
+	ErrStatusNotSet                        = fmt.Errorf("VolumeSnapshotContent: Status not set")
+)
 
 type Scan struct {
 	vscs v1.VolumeSnapshotContentList
@@ -27,9 +32,15 @@ func (s *Scan) UM(duration time.Duration) (resource.UMMeasurement, error) {
 }
 
 func (s *Scan) EDP() (resource.EDPMeasurement, error) {
+	errs := []error{}
 	edp := resource.EDPMeasurement{}
 
 	for _, vsc := range s.vscs.Items {
+		if vsc.Status == nil {
+
+			errs = append(errs, fmt.Errorf("%w: %s", ErrStatusNotSet, vsc.Name))
+			continue
+		}
 		if vsc.Status.ReadyToUse != nil && *vsc.Status.ReadyToUse {
 			currVSC := getSizeInGB(*vsc.Status.RestoreSize)
 			edp.ProvisionedVolumes.SizeGbTotal += currVSC
@@ -38,7 +49,7 @@ func (s *Scan) EDP() (resource.EDPMeasurement, error) {
 		}
 	}
 
-	return edp, nil
+	return edp, errors.Join(errs...)
 }
 
 func getSizeInGB(value int64) int64 {

--- a/pkg/resource/vsc/scan.go
+++ b/pkg/resource/vsc/scan.go
@@ -19,8 +19,9 @@ const (
 )
 
 var (
-	_               resource.ScanConverter = &Scan{}
-	ErrStatusNotSet                        = fmt.Errorf("VolumeSnapshotContent: Status not set")
+	_                    resource.ScanConverter = &Scan{}
+	ErrStatusNotSet                             = fmt.Errorf("VolumeSnapshotContent: Status not set")
+	ErrRestoreSizeNotSet                        = fmt.Errorf("VolumeSnapshotContent: RestoreSize not set")
 )
 
 type Scan struct {
@@ -42,6 +43,10 @@ func (s *Scan) EDP() (resource.EDPMeasurement, error) {
 		}
 
 		if vsc.Status.ReadyToUse != nil && *vsc.Status.ReadyToUse {
+			if vsc.Status.RestoreSize == nil {
+				errs = append(errs, fmt.Errorf("%w: %s", ErrRestoreSizeNotSet, vsc.Name))
+				continue
+			}
 			currVSC := getSizeInGB(*vsc.Status.RestoreSize)
 			edp.ProvisionedVolumes.SizeGbTotal += currVSC
 			edp.ProvisionedVolumes.SizeGbRounded += getVolumeRoundedToFactor(currVSC)

--- a/pkg/resource/vsc/scan_test.go
+++ b/pkg/resource/vsc/scan_test.go
@@ -3,9 +3,6 @@ package vsc
 import (
 	"testing"
 
-
-	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
-
 	v1 "github.com/kubernetes-csi/external-snapshotter/client/v6/apis/volumesnapshot/v1"
 	"github.com/stretchr/testify/require"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"

--- a/pkg/resource/vsc/scan_test.go
+++ b/pkg/resource/vsc/scan_test.go
@@ -137,6 +137,27 @@ func TestScan_EDP(t *testing.T) {
 			},
 			expextedError: ErrStatusNotSet,
 		},
+		{
+			name: "vscs no restore size",
+			vscs: v1.VolumeSnapshotContentList{
+				Items: []v1.VolumeSnapshotContent{
+					{ObjectMeta: metav1.ObjectMeta{Name: "vsc1"},
+						Status: &v1.VolumeSnapshotContentStatus{
+							ReadyToUse:  ptr.To(true),
+							RestoreSize: nil,
+						},
+					},
+				},
+			},
+			expected: resource.EDPMeasurement{
+				ProvisionedVolumes: resource.ProvisionedVolumes{
+					SizeGbTotal:   0,
+					SizeGbRounded: 0,
+					Count:         0,
+				},
+			},
+			expextedError: ErrRestoreSizeNotSet,
+		},
 	}
 
 	for _, test := range tests {

--- a/pkg/resource/vsc/scan_test.go
+++ b/pkg/resource/vsc/scan_test.go
@@ -141,7 +141,8 @@ func TestScan_EDP(t *testing.T) {
 			name: "vscs no restore size",
 			vscs: v1.VolumeSnapshotContentList{
 				Items: []v1.VolumeSnapshotContent{
-					{ObjectMeta: metav1.ObjectMeta{Name: "vsc1"},
+					{
+						ObjectMeta: metav1.ObjectMeta{Name: "vsc1"},
 						Status: &v1.VolumeSnapshotContentStatus{
 							ReadyToUse:  ptr.To(true),
 							RestoreSize: nil,

--- a/pkg/resource/vsc/scan_test.go
+++ b/pkg/resource/vsc/scan_test.go
@@ -1,11 +1,14 @@
 package vsc
 
 import (
-	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"testing"
+
+
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 
 	v1 "github.com/kubernetes-csi/external-snapshotter/client/v6/apis/volumesnapshot/v1"
 	"github.com/stretchr/testify/require"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/utils/ptr"
 
 	"github.com/kyma-project/kyma-metrics-collector/pkg/resource"
@@ -144,10 +147,12 @@ func TestScan_EDP(t *testing.T) {
 			scan := &Scan{
 				vscs: test.vscs,
 			}
+
 			actual, err := scan.EDP()
 			if test.expextedError != nil {
 				require.ErrorIs(t, err, test.expextedError)
 			}
+
 			require.Equal(t, test.expected, actual)
 		})
 	}


### PR DESCRIPTION
## Description

Changes proposed in this pull request (what was done and why):

- Check if the status sub resource is set before accessing it in the [vsc](https://kubernetes.io/docs/concepts/storage/volume-snapshots/#volume-snapshot-contents) scanner
- Check if `Status.RestoreSize` is set before accessing its value

Changes refer to particular issues, PRs or documents:

- 

## Traceability
- [ ] The PR is linked to a GitHub issue.
- [ ] The follow-up issues (if any) are linked in the `Related Issues` section.
- [ ] If the change is user-facing, the documentation has been adjusted.
- [ ] If a CRD is changed, the corresponding Busola ConfigMap has been adjusted.
- [x] The feature is unit-tested.
- [ ] The feature is e2e-tested.

<!--  
Thank you for your contribution!

Before submitting your pull request, adhere to contributing guidelines, templates, the recommended Git workflow, and related documentation, see also https://github.com/kyma-project/community/blob/main/docs/contributing/02-contributing.md
 -->
