### PR TITLE
fix: Do not report errors for VSC without Status

### DIFF
--- a/pkg/resource/vsc/scan.go
+++ b/pkg/resource/vsc/scan.go
@@ -20,7 +20,6 @@ const (
 
 var (
 	_                    resource.ScanConverter = &Scan{}
-	ErrStatusNotSet                             = fmt.Errorf("VolumeSnapshotContent: Status not set")
 	ErrRestoreSizeNotSet                        = fmt.Errorf("VolumeSnapshotContent: RestoreSize not set")
 )
 
@@ -38,7 +37,7 @@ func (s *Scan) EDP() (resource.EDPMeasurement, error) {
 
 	for _, vsc := range s.vscs.Items {
 		if vsc.Status == nil {
-			errs = append(errs, fmt.Errorf("%w: %s", ErrStatusNotSet, vsc.Name))
+			// Skip VSCs without status
 			continue
 		}
 

--- a/pkg/resource/vsc/scan_test.go
+++ b/pkg/resource/vsc/scan_test.go
@@ -135,7 +135,7 @@ func TestScan_EDP(t *testing.T) {
 					Count:         0,
 				},
 			},
-			expextedError: ErrStatusNotSet,
+			expextedError: nil,
 		},
 		{
 			name: "vscs no restore size",


### PR DESCRIPTION
## Description

Changes proposed in this pull request (what was done and why):

- VSC do not always contain a status subresource. If a vsc does not have a status there is also no backing volume configured on the hyperscaler. Therefor it is fine to ignore such resources in the billing system

Changes refer to particular issues, PRs or documents:

- 

## Traceability
- [ ] The PR is linked to a GitHub issue.
- [ ] The follow-up issues (if any) are linked in the `Related Issues` section.
- [ ] If the change is user-facing, the documentation has been adjusted.
- [ ] If a CRD is changed, the corresponding Busola ConfigMap has been adjusted.
- [ ] The feature is unit-tested.
- [ ] The feature is e2e-tested.

<!--  
Thank you for your contribution!

Before submitting your pull request, adhere to contributing guidelines, templates, the recommended Git workflow, and related documentation, see also https://github.com/kyma-project/community/blob/main/docs/contributing/02-contributing.md
 -->
