### PR TITLE
chore: Remove dead config code

### DIFF
--- a/pkg/config/public_cloud_specs.go
+++ b/pkg/config/public_cloud_specs.go
@@ -32,8 +32,6 @@ type Providers struct {
 type Feature struct {
 	CpuCores int     `json:"cpu_cores"`
 	Memory   float64 `json:"memory"`
-	Storage  int     `json:"storage,omitempty"`
-	MaxNICs  int     `json:"max_nics,omitempty"`
 }
 
 type RedisInfo struct {

--- a/pkg/config/public_cloud_specs_test.go
+++ b/pkg/config/public_cloud_specs_test.go
@@ -31,8 +31,6 @@ func TestGetFeature(t *testing.T) {
 			expectedFeature: Feature{
 				CpuCores: 2,
 				Memory:   4,
-				Storage:  20,
-				MaxNICs:  2,
 			},
 		},
 		{
@@ -41,8 +39,6 @@ func TestGetFeature(t *testing.T) {
 			expectedFeature: Feature{
 				CpuCores: 8,
 				Memory:   32,
-				Storage:  200,
-				MaxNICs:  4,
 			},
 		},
 		{
@@ -51,8 +47,6 @@ func TestGetFeature(t *testing.T) {
 			expectedFeature: Feature{
 				CpuCores: 4,
 				Memory:   16,
-				Storage:  0,
-				MaxNICs:  2,
 			},
 		},
 		{
@@ -61,8 +55,6 @@ func TestGetFeature(t *testing.T) {
 			expectedFeature: Feature{
 				CpuCores: 8,
 				Memory:   32,
-				Storage:  0,
-				MaxNICs:  4,
 			},
 		},
 		{
@@ -71,8 +63,6 @@ func TestGetFeature(t *testing.T) {
 			expectedFeature: Feature{
 				CpuCores: 16,
 				Memory:   64,
-				Storage:  0,
-				MaxNICs:  8,
 			},
 		},
 		{
@@ -81,8 +71,6 @@ func TestGetFeature(t *testing.T) {
 			expectedFeature: Feature{
 				CpuCores: 32,
 				Memory:   128,
-				Storage:  0,
-				MaxNICs:  8,
 			},
 		},
 		{
@@ -91,8 +79,6 @@ func TestGetFeature(t *testing.T) {
 			expectedFeature: Feature{
 				CpuCores: 48,
 				Memory:   192,
-				Storage:  0,
-				MaxNICs:  8,
 			},
 		},
 		{
@@ -101,8 +87,6 @@ func TestGetFeature(t *testing.T) {
 			expectedFeature: Feature{
 				CpuCores: 64,
 				Memory:   256,
-				Storage:  0,
-				MaxNICs:  8,
 			},
 		},
 		{

--- a/pkg/testing/fixtures/public_cloud_specs.json
+++ b/pkg/testing/fixtures/public_cloud_specs.json
@@ -3,237 +3,159 @@
     "azure": {
       "standard_a1_v2": {
         "cpu_cores": 1,
-        "memory": 2,
-        "storage": 10,
-        "max_nics": 1
+        "memory": 2
       },
       "standard_a2_v2": {
         "cpu_cores": 2,
-        "memory": 4,
-        "storage": 20,
-        "max_nics": 2
+        "memory": 4
       },
       "standard_a4_v2": {
         "cpu_cores": 4,
-        "memory": 8,
-        "storage": 40,
-        "max_nics": 4
+        "memory": 8
       },
       "standard_a8_v2": {
         "cpu_cores": 8,
-        "memory": 16,
-        "storage": 80,
-        "max_nics": 8
+        "memory": 16
       },
       "standard_a2m_v2": {
         "cpu_cores": 2,
-        "memory": 16,
-        "storage": 20,
-        "max_nics": 2
+        "memory": 16
       },
       "standard_a4m_v2": {
         "cpu_cores": 4,
-        "memory": 32,
-        "storage": 40,
-        "max_nics": 4
+        "memory": 32
       },
       "standard_a8m_v2": {
         "cpu_cores": 8,
-        "memory": 64,
-        "storage": 80,
-        "max_nics": 8
+        "memory": 64
       },
       "standard_d1": {
         "cpu_cores": 1,
-        "memory": 3.5,
-        "storage": 50,
-        "max_nics": 1
+        "memory": 3.5
       },
       "standard_d2": {
         "cpu_cores": 2,
-        "memory": 7,
-        "storage": 100,
-        "max_nics": 2
+        "memory": 7
       },
       "standard_d3": {
         "cpu_cores": 4,
-        "memory": 14,
-        "storage": 200,
-        "max_nics": 4
+        "memory": 14
       },
       "standard_d4": {
         "cpu_cores": 8,
-        "memory": 128,
-        "storage": 400,
-        "max_nics": 8
+        "memory": 128
       },
       "standard_d11": {
         "cpu_cores": 2,
-        "memory": 14,
-        "storage": 100,
-        "max_nics": 2
+        "memory": 14
       },
       "standard_d12": {
         "cpu_cores": 4,
-        "memory": 28,
-        "storage": 200,
-        "max_nics": 4
+        "memory": 28
       },
       "standard_d13": {
         "cpu_cores": 8,
-        "memory": 56,
-        "storage": 400,
-        "max_nics": 8
+        "memory": 56
       },
       "standard_d14": {
         "cpu_cores": 16,
-        "memory": 112,
-        "storage": 800,
-        "max_nics": 8
+        "memory": 112
       },
       "standard_d1_v2": {
         "cpu_cores": 1,
-        "memory": 3.5,
-        "storage": 50,
-        "max_nics": 1
+        "memory": 3.5
       },
       "standard_d2_v2": {
         "cpu_cores": 2,
-        "memory": 7,
-        "storage": 100,
-        "max_nics": 2
+        "memory": 7
       },
       "standard_d3_v2": {
         "cpu_cores": 4,
-        "memory": 14,
-        "storage": 200,
-        "max_nics": 4
+        "memory": 14
       },
       "standard_d4_v2": {
         "cpu_cores": 8,
-        "memory": 28,
-        "storage": 400,
-        "max_nics": 8
+        "memory": 28
       },
       "standard_d5_v2": {
         "cpu_cores": 16,
-        "memory": 56,
-        "storage": 800,
-        "max_nics": 8
+        "memory": 56
       },
       "standard_d11_v2": {
         "cpu_cores": 2,
-        "memory": 14,
-        "storage": 100,
-        "max_nics": 2
+        "memory": 14
       },
       "standard_d12_v2": {
         "cpu_cores": 4,
-        "memory": 28,
-        "storage": 200,
-        "max_nics": 4
+        "memory": 28
       },
       "standard_d13_v2": {
         "cpu_cores": 8,
-        "memory": 56,
-        "storage": 400,
-        "max_nics": 8
+        "memory": 56
       },
       "standard_d14_v2": {
         "cpu_cores": 16,
-        "memory": 112,
-        "storage": 800,
-        "max_nics": 8
+        "memory": 112
       },
       "standard_d15_v2": {
         "cpu_cores": 20,
-        "memory": 140,
-        "storage": 1000,
-        "max_nics": 8
+        "memory": 140
       },
       "standard_d2_v3": {
         "cpu_cores": 2,
-        "memory": 8,
-        "storage": 50,
-        "max_nics": 2
+        "memory": 8
       },
       "standard_d4_v3": {
         "cpu_cores": 4,
-        "memory": 16,
-        "storage": 100,
-        "max_nics": 2
+        "memory": 16
       },
       "standard_d8_v3": {
         "cpu_cores": 8,
-        "memory": 32,
-        "storage": 200,
-        "max_nics": 4
+        "memory": 32
       },
       "standard_d16_v3": {
         "cpu_cores": 16,
-        "memory": 64,
-        "storage": 400,
-        "max_nics": 8
+        "memory": 64
       },
       "standard_d32_v3": {
         "cpu_cores": 32,
-        "memory": 128,
-        "storage": 800,
-        "max_nics": 8
+        "memory": 128
       },
       "standard_d48_v3": {
         "cpu_cores": 48,
-        "memory": 192,
-        "storage": 1200,
-        "max_nics": 8
+        "memory": 192
       },
       "standard_d64_v3": {
         "cpu_cores": 64,
-        "memory": 256,
-        "storage": 1600,
-        "max_nics": 8
+        "memory": 256
       },
       "standard_d4s_v5": {
         "cpu_cores": 4,
-        "memory": 16,
-        "storage": 0,
-        "max_nics": 2
+        "memory": 16
       },
       "standard_d8s_v5": {
         "cpu_cores": 8,
-        "memory": 32,
-        "storage": 0,
-        "max_nics": 4
+        "memory": 32
       },
       "standard_d16s_v5": {
         "cpu_cores": 16,
-        "memory": 64,
-        "storage": 0,
-        "max_nics": 8
+        "memory": 64
       },
       "standard_d32s_v5": {
         "cpu_cores": 32,
-        "memory": 128,
-        "storage": 0,
-        "max_nics": 8
+        "memory": 128
       },
       "standard_d48s_v5": {
         "cpu_cores": 48,
-        "memory": 192,
-        "storage": 0,
-        "max_nics": 8
+        "memory": 192
       },
       "standard_d64s_v5": {
         "cpu_cores": 64,
-        "memory": 256,
-        "storage": 0,
-        "max_nics": 8
+        "memory": 256
       },
       "standard_d2s_v5": {
         "cpu_cores": 3,
-        "memory": 8,
-        "storage": 0,
-        "max_nics": 2
+        "memory": 8
       }
     },
     "aws": {

--- a/pkg/testing/fixtures/public_cloud_specs_no_aws.json
+++ b/pkg/testing/fixtures/public_cloud_specs_no_aws.json
@@ -3,9 +3,7 @@
     "azure": {
       "standard_a1_v2": {
         "cpu_cores": 1,
-        "memory": 2,
-        "storage": 10,
-        "max_nics": 1
+        "memory": 2
       }
     },
     "aws": {

--- a/pkg/testing/fixtures/public_cloud_specs_no_azure.json
+++ b/pkg/testing/fixtures/public_cloud_specs_no_azure.json
@@ -3,9 +3,7 @@
     "azure": {
       "standard_a1_v2": {
         "cpu_cores": 1,
-        "memory": 2,
-        "storage": 10,
-        "max_nics": 1
+        "memory": 2
       }
     },
     "aws": {

--- a/pkg/testing/fixtures/public_cloud_specs_no_ccee.json
+++ b/pkg/testing/fixtures/public_cloud_specs_no_ccee.json
@@ -3,9 +3,7 @@
     "azure": {
       "standard_a1_v2": {
         "cpu_cores": 1,
-        "memory": 2,
-        "storage": 10,
-        "max_nics": 1
+        "memory": 2
       }
     },
     "aws": {

--- a/pkg/testing/fixtures/public_cloud_specs_no_gcp.json
+++ b/pkg/testing/fixtures/public_cloud_specs_no_gcp.json
@@ -3,9 +3,7 @@
     "azure": {
       "standard_a1_v2": {
         "cpu_cores": 1,
-        "memory": 2,
-        "storage": 10,
-        "max_nics": 1
+        "memory": 2
       }
     },
     "aws": {

--- a/pkg/testing/fixtures/public_cloud_specs_no_redis.json
+++ b/pkg/testing/fixtures/public_cloud_specs_no_redis.json
@@ -3,237 +3,159 @@
     "azure": {
       "standard_a1_v2": {
         "cpu_cores": 1,
-        "memory": 2,
-        "storage": 10,
-        "max_nics": 1
+        "memory": 2
       },
       "standard_a2_v2": {
         "cpu_cores": 2,
-        "memory": 4,
-        "storage": 20,
-        "max_nics": 2
+        "memory": 4
       },
       "standard_a4_v2": {
         "cpu_cores": 4,
-        "memory": 8,
-        "storage": 40,
-        "max_nics": 4
+        "memory": 8
       },
       "standard_a8_v2": {
         "cpu_cores": 8,
-        "memory": 16,
-        "storage": 80,
-        "max_nics": 8
+        "memory": 16
       },
       "standard_a2m_v2": {
         "cpu_cores": 2,
-        "memory": 16,
-        "storage": 20,
-        "max_nics": 2
+        "memory": 16
       },
       "standard_a4m_v2": {
         "cpu_cores": 4,
-        "memory": 32,
-        "storage": 40,
-        "max_nics": 4
+        "memory": 32
       },
       "standard_a8m_v2": {
         "cpu_cores": 8,
-        "memory": 64,
-        "storage": 80,
-        "max_nics": 8
+        "memory": 64
       },
       "standard_d1": {
         "cpu_cores": 1,
-        "memory": 3.5,
-        "storage": 50,
-        "max_nics": 1
+        "memory": 3.5
       },
       "standard_d2": {
         "cpu_cores": 2,
-        "memory": 7,
-        "storage": 100,
-        "max_nics": 2
+        "memory": 7
       },
       "standard_d3": {
         "cpu_cores": 4,
-        "memory": 14,
-        "storage": 200,
-        "max_nics": 4
+        "memory": 14
       },
       "standard_d4": {
         "cpu_cores": 8,
-        "memory": 128,
-        "storage": 400,
-        "max_nics": 8
+        "memory": 128
       },
       "standard_d11": {
         "cpu_cores": 2,
-        "memory": 14,
-        "storage": 100,
-        "max_nics": 2
+        "memory": 14
       },
       "standard_d12": {
         "cpu_cores": 4,
-        "memory": 28,
-        "storage": 200,
-        "max_nics": 4
+        "memory": 28
       },
       "standard_d13": {
         "cpu_cores": 8,
-        "memory": 56,
-        "storage": 400,
-        "max_nics": 8
+        "memory": 56
       },
       "standard_d14": {
         "cpu_cores": 16,
-        "memory": 112,
-        "storage": 800,
-        "max_nics": 8
+        "memory": 112
       },
       "standard_d1_v2": {
         "cpu_cores": 1,
-        "memory": 3.5,
-        "storage": 50,
-        "max_nics": 1
+        "memory": 3.5
       },
       "standard_d2_v2": {
         "cpu_cores": 2,
-        "memory": 7,
-        "storage": 100,
-        "max_nics": 2
+        "memory": 7
       },
       "standard_d3_v2": {
         "cpu_cores": 4,
-        "memory": 14,
-        "storage": 200,
-        "max_nics": 4
+        "memory": 14
       },
       "standard_d4_v2": {
         "cpu_cores": 8,
-        "memory": 28,
-        "storage": 400,
-        "max_nics": 8
+        "memory": 28
       },
       "standard_d5_v2": {
         "cpu_cores": 16,
-        "memory": 56,
-        "storage": 800,
-        "max_nics": 8
+        "memory": 56
       },
       "standard_d11_v2": {
         "cpu_cores": 2,
-        "memory": 14,
-        "storage": 100,
-        "max_nics": 2
+        "memory": 14
       },
       "standard_d12_v2": {
         "cpu_cores": 4,
-        "memory": 28,
-        "storage": 200,
-        "max_nics": 4
+        "memory": 28
       },
       "standard_d13_v2": {
         "cpu_cores": 8,
-        "memory": 56,
-        "storage": 400,
-        "max_nics": 8
+        "memory": 56
       },
       "standard_d14_v2": {
         "cpu_cores": 16,
-        "memory": 112,
-        "storage": 800,
-        "max_nics": 8
+        "memory": 112
       },
       "standard_d15_v2": {
         "cpu_cores": 20,
-        "memory": 140,
-        "storage": 1000,
-        "max_nics": 8
+        "memory": 140
       },
       "standard_d2_v3": {
         "cpu_cores": 2,
-        "memory": 8,
-        "storage": 50,
-        "max_nics": 2
+        "memory": 8
       },
       "standard_d4_v3": {
         "cpu_cores": 4,
-        "memory": 16,
-        "storage": 100,
-        "max_nics": 2
+        "memory": 16
       },
       "standard_d8_v3": {
         "cpu_cores": 8,
-        "memory": 32,
-        "storage": 200,
-        "max_nics": 4
+        "memory": 32
       },
       "standard_d16_v3": {
         "cpu_cores": 16,
-        "memory": 64,
-        "storage": 400,
-        "max_nics": 8
+        "memory": 64
       },
       "standard_d32_v3": {
         "cpu_cores": 32,
-        "memory": 128,
-        "storage": 800,
-        "max_nics": 8
+        "memory": 128
       },
       "standard_d48_v3": {
         "cpu_cores": 48,
-        "memory": 192,
-        "storage": 1200,
-        "max_nics": 8
+        "memory": 192
       },
       "standard_d64_v3": {
         "cpu_cores": 64,
-        "memory": 256,
-        "storage": 1600,
-        "max_nics": 8
+        "memory": 256
       },
       "standard_d4s_v5": {
         "cpu_cores": 4,
-        "memory": 16,
-        "storage": 0,
-        "max_nics": 2
+        "memory": 16
       },
       "standard_d8s_v5": {
         "cpu_cores": 8,
-        "memory": 32,
-        "storage": 0,
-        "max_nics": 4
+        "memory": 32
       },
       "standard_d16s_v5": {
         "cpu_cores": 16,
-        "memory": 64,
-        "storage": 0,
-        "max_nics": 8
+        "memory": 64
       },
       "standard_d32s_v5": {
         "cpu_cores": 32,
-        "memory": 128,
-        "storage": 0,
-        "max_nics": 8
+        "memory": 128
       },
       "standard_d48s_v5": {
         "cpu_cores": 48,
-        "memory": 192,
-        "storage": 0,
-        "max_nics": 8
+        "memory": 192
       },
       "standard_d64s_v5": {
         "cpu_cores": 64,
-        "memory": 256,
-        "storage": 0,
-        "max_nics": 8
+        "memory": 256
       },
       "standard_d2s_v5": {
         "cpu_cores": 3,
-        "memory": 8,
-        "storage": 0,
-        "max_nics": 2
+        "memory": 8
       }
     },
     "aws": {


### PR DESCRIPTION
## Description

Changes proposed in this pull request (what was done and why):

- The storage and network config is read but not used
- The config is only available for azure types
- Removed it fully to avoid dead code

Changes refer to particular issues, PRs or documents:

- 

## Traceability
- [ ] The PR is linked to a GitHub issue.
- [ ] The follow-up issues (if any) are linked in the `Related Issues` section.
- [ ] If the change is user-facing, the documentation has been adjusted.
- [ ] If a CRD is changed, the corresponding Busola ConfigMap has been adjusted.
- [ ] The feature is unit-tested.
- [ ] The feature is e2e-tested.

<!--  
Thank you for your contribution!

Before submitting your pull request, adhere to contributing guidelines, templates, the recommended Git workflow, and related documentation, see also https://github.com/kyma-project/community/blob/main/docs/contributing/02-contributing.md
 -->
