### PR TITLE
chore: (pvc, nfs) use nfs capacity label as primary source of truth 

### DIFF
--- a/pkg/resource/pvc/scan_test.go
+++ b/pkg/resource/pvc/scan_test.go
@@ -108,6 +108,89 @@ func TestScan_EDP(t *testing.T) {
 				},
 			},
 		},
+		{
+			name: "cloud-manager with no nfs capacity label",
+			pvcs: corev1.PersistentVolumeClaimList{
+				Items: []corev1.PersistentVolumeClaim{
+					{
+						ObjectMeta: metav1.ObjectMeta{
+							Labels: map[string]string{
+								"app.kubernetes.io/component":  "cloud-manager",
+								"app.kubernetes.io/part-of":    "kyma",
+								"app.kubernetes.io/managed-by": "cloud-manager",
+							}, // NFS labels
+						},
+						Status: corev1.PersistentVolumeClaimStatus{
+							Phase:    corev1.ClaimBound,
+							Capacity: corev1.ResourceList{corev1.ResourceStorage: apiresource.MustParse("20Gi")},
+						},
+					},
+				},
+			},
+			expected: resource.EDPMeasurement{
+				ProvisionedVolumes: resource.ProvisionedVolumes{
+					SizeGbTotal:   60, // 3 * 20
+					SizeGbRounded: 64, // 2 * 32
+					Count:         1,
+				},
+			},
+		},
+		{
+			name: "cloud-manager with nfs capacity label taking priority",
+			pvcs: corev1.PersistentVolumeClaimList{
+				Items: []corev1.PersistentVolumeClaim{
+					{
+						ObjectMeta: metav1.ObjectMeta{
+							Labels: map[string]string{
+								"app.kubernetes.io/component":                              "cloud-manager",
+								"app.kubernetes.io/part-of":                                "kyma",
+								"app.kubernetes.io/managed-by":                             "cloud-manager",
+								"cloud-resources.kyma-project.io/nfsVolumeStorageCapacity": "40Gi",
+							}, // NFS labels
+						},
+						Status: corev1.PersistentVolumeClaimStatus{
+							Phase:    corev1.ClaimBound,
+							Capacity: corev1.ResourceList{corev1.ResourceStorage: apiresource.MustParse("20Gi")},
+						},
+					},
+				},
+			},
+			expected: resource.EDPMeasurement{
+				ProvisionedVolumes: resource.ProvisionedVolumes{
+					SizeGbTotal:   120, // 3 * 40
+					SizeGbRounded: 128, // 32 * 4
+					Count:         1,
+				},
+			},
+		},
+		{
+			name: "cloud-manager with unparasable nfs capacity label using pvc capacity as fallback",
+			pvcs: corev1.PersistentVolumeClaimList{
+				Items: []corev1.PersistentVolumeClaim{
+					{
+						ObjectMeta: metav1.ObjectMeta{
+							Labels: map[string]string{
+								"app.kubernetes.io/component":                              "cloud-manager",
+								"app.kubernetes.io/part-of":                                "kyma",
+								"app.kubernetes.io/managed-by":                             "cloud-manager",
+								"cloud-resources.kyma-project.io/nfsVolumeStorageCapacity": "invalid value",
+							}, // NFS labels
+						},
+						Status: corev1.PersistentVolumeClaimStatus{
+							Phase:    corev1.ClaimBound,
+							Capacity: corev1.ResourceList{corev1.ResourceStorage: apiresource.MustParse("20Gi")},
+						},
+					},
+				},
+			},
+			expected: resource.EDPMeasurement{
+				ProvisionedVolumes: resource.ProvisionedVolumes{
+					SizeGbTotal:   60, // 3 * 20
+					SizeGbRounded: 64, // 2 * 32
+					Count:         1,
+				},
+			},
+		},
 	}
 
 	for _, test := range tests {

--- a/pkg/resource/pvc/scan_test.go
+++ b/pkg/resource/pvc/scan_test.go
@@ -164,7 +164,7 @@ func TestScan_EDP(t *testing.T) {
 			},
 		},
 		{
-			name: "cloud-manager with unparasable nfs capacity label using pvc capacity as fallback",
+			name: "cloud-manager with unparseable nfs capacity label using pvc capacity as fallback",
 			pvcs: corev1.PersistentVolumeClaimList{
 				Items: []corev1.PersistentVolumeClaim{
 					{


### PR DESCRIPTION
## Description

Changes proposed in this pull request (what was done and why):

- Use `"cloud-resources.kyma-project.io/nfsVolumeStorageCapacity"` label as primary source of truth when calculating consumed PVC storage capacity.
  - handle case of missing label
  - handle case of invalid label format (non-parseable by Quantity)
  -  keep using pvc.storage.capacity() as fallback mechanism

As PVC storage capacity is currently non-modifiable, this is used as a temporary* solution



Changes refer to particular issues, PRs or documents:

- kyma/backlog#6764

## Traceability
- [x] The PR is linked to a GitHub issue.
- [ ] The follow-up issues (if any) are linked in the `Related Issues` section.
- [ ] If the change is user-facing, the documentation has been adjusted.
- [ ] If a CRD is changed, the corresponding Busola ConfigMap has been adjusted.
- [x] The feature is unit-tested.
- [ ] The feature is e2e-tested.

<!--  
Thank you for your contribution!

Before submitting your pull request, adhere to contributing guidelines, templates, the recommended Git workflow, and related documentation, see also https://github.com/kyma-project/community/blob/main/docs/contributing/02-contributing.md
 -->
---
*_Nothing is more permanent than a temporary solution._